### PR TITLE
assigning categories to products in seed.js

### DIFF
--- a/client/components/productCategory.js
+++ b/client/components/productCategory.js
@@ -33,7 +33,8 @@ class ProductCategory extends React.Component {
 
 const mapStateToProps = state => {
   return {
-    products: state.product.filteredProducts
+    products: state.product.filteredProducts,
+    //category: state.chosenCategory
   }
 }
 

--- a/client/components/productCategory.js
+++ b/client/components/productCategory.js
@@ -33,7 +33,7 @@ class ProductCategory extends React.Component {
 
 const mapStateToProps = state => {
   return {
-    products: state.product.products
+    products: state.product.filteredProducts
   }
 }
 

--- a/client/store/product.js
+++ b/client/store/product.js
@@ -97,6 +97,7 @@ export const fetchByCategory = category => {
   return async dispatch => {
     const response = await axios.get(`/api/product/category/${category}`)
     const products = response.data
+    console.log('fetchByCategory products',products)
     dispatch(gotProductCategory(products))
   }
 }
@@ -137,6 +138,7 @@ export const getAllCategories = () => {
 const initialState = {
   products: [],
   singleProduct: {},
+  filteredProducts: [],
   reviews: [],
   productReview: {},
   product: {},
@@ -157,7 +159,7 @@ const productReducer = (state = initialState, action) => {
       return {
         ...state,
         error: null,
-        products: action.products
+        filteredProducts: action.products
       }
     case GOT_SINGLE_PRODUCT:
       return {...state, error: null, singleProduct: {...action.product}}

--- a/script/seed.js
+++ b/script/seed.js
@@ -342,9 +342,39 @@ function seed() {
     .then(newCategories => {
       createdCategories = newCategories
       const newOne = createdProducts[0].addCategories(createdCategories[0])
-      const newTwo = createdProducts[1].addCategories(createdCategories[1])
-      const newThree = createdProducts[2].addCategories(createdCategories[2])
-      return newOne, newTwo, newThree
+      const newTwo = createdProducts[1].addCategories(createdCategories[0])
+      const newThree = createdProducts[2].addCategories(createdCategories[0])
+      const newFour = createdProducts[3].addCategories(createdCategories[0])
+      const newFive = createdProducts[4].addCategories(createdCategories[0])
+      const newSix = createdProducts[5].addCategories(createdCategories[0])
+      const newSeven = createdProducts[6].addCategories(createdCategories[0])
+      const newEight = createdProducts[7].addCategories(createdCategories[0])
+      const newNine = createdProducts[8].addCategories(createdCategories[0])
+      const newTen = createdProducts[9].addCategories(createdCategories[0])
+
+      const newEleven = createdProducts[10].addCategories(createdCategories[1])
+      const newTwelve = createdProducts[11].addCategories(createdCategories[1])
+      const newThirteen = createdProducts[12].addCategories(createdCategories[1])
+      const newFourteen = createdProducts[13].addCategories(createdCategories[1])
+      const newFifteen = createdProducts[14].addCategories(createdCategories[1])
+      const newSixteen = createdProducts[15].addCategories(createdCategories[1])
+      const newSeventeen = createdProducts[16].addCategories(createdCategories[1])
+      const newEighteen = createdProducts[17].addCategories(createdCategories[1])
+      const newNineteen = createdProducts[18].addCategories(createdCategories[1])
+      const newTwenty = createdProducts[19].addCategories(createdCategories[1])
+
+      const newTwentyOne = createdProducts[20].addCategories(createdCategories[2])
+      const newTwentyTwo = createdProducts[21].addCategories(createdCategories[2])
+      const newTwentyThree = createdProducts[22].addCategories(createdCategories[2])
+      const newTwentyFour = createdProducts[23].addCategories(createdCategories[2])
+      const newTwentyFive = createdProducts[24].addCategories(createdCategories[2])
+      const newTwentySix = createdProducts[25].addCategories(createdCategories[2])
+      const newTwentySeven = createdProducts[26].addCategories(createdCategories[2])
+     
+      return newOne, newTwo, newThree, newFour, newFive, newSix, newSeven, newEight, newNine, newTen,
+      newEleven, newTwelve, newThirteen, newFourteen, newFifteen, newSixteen, newSeventeen,
+      newEighteen, newNineteen, newTwenty, newTwentyOne, newTwentyTwo, newTwentyThree, newTwentyFour, 
+      newTwentyFive, newTwentySix, newTwentySeven
     })
     .catch(error => console.error(error))
   // .then(() => {


### PR DESCRIPTION
Success:
assigned all products to a category

There is a bug: 
- users can switch categories from Products or from Home. 
- users cannot switch categories directly from another category - attempting to change categories from another results in seeing the same exact page
-if a user types the category url (ie. http://localhost:8080/product/category/Music) directly into the browser, then this results in seeing all products
-with testing, this bug did not affect other functionality.